### PR TITLE
Support MacPorts

### DIFF
--- a/src/main/kotlin/com.tmiyamon.mdicons/cmd/Command.kt
+++ b/src/main/kotlin/com.tmiyamon.mdicons/cmd/Command.kt
@@ -10,7 +10,7 @@ fun exec(vararg strs: String): Int {
 }
 
 interface Command {
-    fun searchPath() = arrayOf("/usr/bin", "/usr/local/bin")
+    fun searchPath() = arrayOf("/usr/bin", "/usr/local/bin", "/opt/local/bin")
 
     fun findBin(binName: String): String {
         //TODO support windows


### PR DESCRIPTION
Add `/opt/local/bin` (the bin folder used by MacPorts) to the `convert` searchPath.
